### PR TITLE
Service tracing and error handling

### DIFF
--- a/src/infra/bus.js
+++ b/src/infra/bus.js
@@ -1,9 +1,12 @@
 /** @typedef {import('./types').Bus} BusInterface */
+/** @typedef {import('./types').CommandHandler} CommandHandler */
 import { EventEmitter } from 'node:events';
+import { randomUUID } from 'node:crypto';
 
 /** @implements {BusInterface} */
 class Bus {
   #ee;
+  /** @type {Map<string, Record<string, CommandHandler>>} */
   #services;
 
   constructor() {
@@ -14,7 +17,24 @@ class Bus {
   /** @type BusInterface['command'] */
   command({ service: serviceName, method }, payload) {
     const service = this.#services.get(serviceName);
-    return service[method](payload);
+    if (!service) {
+      return Promise.resolve([
+        { expected: false, message: 'Service not found' },
+        null,
+      ]);
+    }
+
+    const handler = service[method];
+    if (!handler) {
+      return Promise.resolve([
+        { expected: false, message: 'Method not found' },
+        null,
+      ]);
+    }
+
+    const operationId = randomUUID();
+    const wrappedMeta = { ...payload.meta, operationId };
+    return handler({ ...payload, meta: wrappedMeta });
   }
 
   /** @type BusInterface['registerService'] */

--- a/src/infra/types.d.ts
+++ b/src/infra/types.d.ts
@@ -6,8 +6,7 @@ export interface DefaultMeta {
   [key: string]: unknown;
 }
 export type Payload<Meta = object, Data = unknown> = { meta: Meta, data: Data };
-export type Event = Payload;
-type EventHandler = (event: Event) => any;
+export type EventHandler = (event: Payload<DefaultMeta>) => Promise<void>;
 export type CommandHandler = (payload: Payload<DefaultMeta>) => Promise<CommandResult>;
 export type ServiceError = { message: string; expected: boolean };
 export type CommandResult = [ServiceError | null, any];
@@ -19,7 +18,7 @@ export interface Bus {
   registerService(name: string, service: Record<string, CommandHandler>): void;
   unsubscribe(eventName: string, handler: EventHandler): boolean;
   subscribe(eventName: string, handler: EventHandler): boolean;
-  publish(eventName: string, event: Event): boolean;
+  publish(eventName: string, payload: Payload): boolean;
 }
 
 export type Infra = {

--- a/src/server/plugins/websocket/websocket.js
+++ b/src/server/plugins/websocket/websocket.js
@@ -26,8 +26,8 @@ const websocket = async (fastify, options) => {
       const { accountId } = req.session;
       const wsId = randomUUID();
 
-      /** @type {(payload: { meta?: any, data: any}) => void} */
-      const messageHandler = ({ meta, data }) => {
+      /** @type {(payload: { meta?: any, data: any}) => Promise<void>} */
+      const messageHandler = async ({ meta, data }) => {
         const { wsId } = meta;
         const socket = wsConnections.get(wsId);
         socket.send(JSON.stringify(data));

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -22,11 +22,14 @@ export const init = async (infra, api, options) => {
 
   await server.register(swagger, options.swagger);
   await server.register(customAuth, {
-    verifyToken: (token, definition) =>
-      bus.command(
+    verifyToken: async (token, definition) => {
+      const [error, result] = await bus.command(
         { service: 'auth', method: 'verify' },
-        { data: { token, definition } },
-      ),
+        { meta: { definition }, data: { token } },
+      );
+      if (error) return { valid: false };
+      return result;
+    },
   });
 
   if (api.http) {

--- a/src/services/account/account.js
+++ b/src/services/account/account.js
@@ -18,7 +18,7 @@ const deposit = async (infra, { data: { accountId, amount } }) => {
       typeExternal: 'deposit',
     },
   });
-  bus.publish('account.deposit', { meta: null, data: { accountId, amount } });
+  bus.publish('account.deposit', { meta: {}, data: { accountId, amount } });
 };
 
 /** @type Commands['withdraw'] */
@@ -42,7 +42,7 @@ const withdraw = async (infra, { data: { accountId, amount } }) => {
       },
     });
   });
-  bus.publish('account.withdraw', { meta: null, data: { accountId, amount } });
+  bus.publish('account.withdraw', { meta: {}, data: { accountId, amount } });
 };
 
 /** @type Commands['transfer'] */
@@ -73,7 +73,7 @@ const transfer = async (infra, { data: { fromId, toId, amount } }) => {
     });
   });
   bus.publish('account.transfer', {
-    meta: null,
+    meta: {},
     data: {
       fromId,
       toId,
@@ -90,7 +90,7 @@ const transfer = async (infra, { data: { fromId, toId, amount } }) => {
     },
   });
   bus.publish('account.transfer', {
-    meta: null,
+    meta: {},
     data: {
       fromId,
       toId,
@@ -109,7 +109,7 @@ const transfer = async (infra, { data: { fromId, toId, amount } }) => {
     },
   });
   bus.publish('account.transfer', {
-    meta: null,
+    meta: {},
     data: {
       fromId,
       toId,

--- a/src/services/auth/auth.js
+++ b/src/services/auth/auth.js
@@ -18,7 +18,7 @@ const signUp = async (infra, { data: { email, password, ...rest } }) => {
   const token = crypto.random();
   await db.session.create({ data: { userId, token } });
 
-  bus.publish('auth.signUp', { meta: null, data: { email } });
+  bus.publish('auth.signUp', { meta: {}, data: { email } });
 
   return { userId, token };
 };

--- a/src/services/error.js
+++ b/src/services/error.js
@@ -1,0 +1,15 @@
+/** @typedef {import('./types')} ServiceFuncs */
+
+export class ServiceError extends Error {}
+
+/** @type ServiceFuncs['processServiceError'] */
+export const processServiceError = (error, logger, options) => {
+  const { logPrefix, operationId } = options;
+    const expected = error instanceof ServiceError;
+    const { message, stack } = error;
+    logger[expected ? 'warn' : 'error'](
+      { stack, operationId },
+      `[${logPrefix}] ${message}`,
+    );
+    return { message, expected };
+};

--- a/src/services/error.js
+++ b/src/services/error.js
@@ -5,11 +5,11 @@ export class ServiceError extends Error {}
 /** @type ServiceFuncs['processServiceError'] */
 export const processServiceError = (error, logger, options) => {
   const { logPrefix, operationId } = options;
-    const expected = error instanceof ServiceError;
-    const { message, stack } = error;
-    logger[expected ? 'warn' : 'error'](
-      { stack, operationId },
-      `[${logPrefix}] ${message}`,
-    );
-    return { message, expected };
+  const expected = error instanceof ServiceError;
+  const { message, stack } = error;
+  logger[expected ? 'warn' : 'error'](
+    { stack, operationId },
+    `[${logPrefix}] ${message}`,
+  );
+  return { message, expected };
 };

--- a/src/services/notification/notification.js
+++ b/src/services/notification/notification.js
@@ -1,5 +1,5 @@
 /** @typedef {import('./types').NotificationEventHandlers} EventHandlers */
-import { AppError } from '../../lib/error.js';
+import { ServiceError } from '../error.js';
 
 const initialisedUsers = new Map();
 
@@ -26,12 +26,12 @@ const accountTransfer = async (infra, { data }) => {
     where: { id: fromId },
     include: { owner: true },
   });
-  if (!sender) throw new AppError('Sender not found');
+  if (!sender) throw new ServiceError('Sender not found');
   const receiver = await db.account.findUnique({
     where: { id: toId },
     include: { owner: true },
   });
-  if (!receiver) throw new AppError('Receiver not found');
+  if (!receiver) throw new ServiceError('Receiver not found');
 
   const senderMeta = initialisedUsers.get(sender.owner.id);
   if (senderMeta) {

--- a/src/services/services.js
+++ b/src/services/services.js
@@ -1,10 +1,9 @@
 /** @typedef {import('./types')} ServiceFuncs */
 /** @typedef {import('./types').Service} Service */
-/** @typedef {import('./types').WrappedCommandResult} CommandResult */
 import * as auth from './auth/auth.js';
 import * as account from './account/account.js';
 import * as notification from './notification/notification.js';
-import { AppError } from '../lib/error.js';
+import { processServiceError } from './error.js';
 
 /** @type {Record<string, Service>} */
 const services = {
@@ -13,16 +12,12 @@ const services = {
   notification,
 };
 
-/** @type ServiceFuncs['wrapCommand'] */
-const wrapCommand = (infra, func) => async (payload) => {
-  try {
-    const result = func(infra, payload);
-    return [null, result];
-  } catch (/** @type any */ error) {
-    const expected = error instanceof AppError;
-    /** @type CommandResult */
-    const wrapped = [{ message: error?.message, expected }, null];
-    return wrapped;
+/** @type ServiceFuncs['init'] */
+export const init = async (infra) => {
+  for (const [name, service] of Object.entries(services)) {
+    const { commands, eventHandlers } = service;
+    if (commands) initCommands(infra, name, commands);
+    if (eventHandlers) initEventHandlers(infra, eventHandlers);
   }
 };
 
@@ -32,7 +27,9 @@ const initCommands = (infra, serviceName, commands) => {
   const initialized = {};
 
   for (const [name, fn] of Object.entries(commands)) {
-    initialized[name] = wrapCommand(infra, fn);
+    initialized[name] = wrapCommand(infra, fn, {
+      logPrefix: `${serviceName}/${name}`,
+    });
   }
 
   infra.bus.registerService(serviceName, initialized);
@@ -45,11 +42,19 @@ const initEventHandlers = (infra, handlers) => {
   }
 };
 
-/** @type ServiceFuncs['init'] */
-export const init = async (infra) => {
-  for (const [name, service] of Object.entries(services)) {
-    const { commands, eventHandlers } = service;
-    if (commands) initCommands(infra, name, commands);
-    if (eventHandlers) initEventHandlers(infra, eventHandlers);
+/** @type ServiceFuncs['wrapCommand'] */
+const wrapCommand = (infra, func, options) => async (payload) => {
+  const { logger } = infra;
+  const { logPrefix } = options;
+  const { operationId } = payload.meta;
+  try {
+    const result = func(infra, payload);
+    return [null, result];
+  } catch (error) {
+    const serviceError = processServiceError(error, logger, {
+      operationId,
+      logPrefix,
+    });
+    return [serviceError, null];
   }
 };

--- a/src/services/services.js
+++ b/src/services/services.js
@@ -1,38 +1,51 @@
+/** @typedef {import('./types')} ServiceFuncs */
 /** @typedef {import('./types').Service} Service */
-/** @typedef {import('./types').initCommands} initCommands */
-/** @typedef {import('./types').initEventHandlers} initEventHandlers */
-/** @typedef {import('./types').init} init */
-import * as notification from './notification/notification.js';
+/** @typedef {import('./types').WrappedCommandResult} CommandResult */
 import * as auth from './auth/auth.js';
 import * as account from './account/account.js';
+import * as notification from './notification/notification.js';
+import { AppError } from '../lib/error.js';
 
 /** @type {Record<string, Service>} */
 const services = {
   auth,
-  notification,
   account,
+  notification,
 };
 
-/** @type initCommands */
+/** @type ServiceFuncs['wrapCommand'] */
+const wrapCommand = (infra, func) => async (payload) => {
+  try {
+    const result = func(infra, payload);
+    return [null, result];
+  } catch (/** @type any */ error) {
+    const expected = error instanceof AppError;
+    /** @type CommandResult */
+    const wrapped = [{ message: error?.message, expected }, null];
+    return wrapped;
+  }
+};
+
+/** @type ServiceFuncs['initCommands'] */
 const initCommands = (infra, serviceName, commands) => {
   /** @type Service['commands'] */
   const initialized = {};
 
   for (const [name, fn] of Object.entries(commands)) {
-    initialized[name] = fn.bind(null, infra);
+    initialized[name] = wrapCommand(infra, fn);
   }
 
   infra.bus.registerService(serviceName, initialized);
 };
 
-/** @type initEventHandlers */
+/** @type ServiceFuncs['initEventHandlers'] */
 const initEventHandlers = (infra, handlers) => {
   for (const [eventName, handler] of Object.entries(handlers)) {
     infra.bus.subscribe(eventName, handler.bind(null, infra));
   }
 };
 
-/** @type init */
+/** @type ServiceFuncs['init'] */
 export const init = async (infra) => {
   for (const [name, service] of Object.entries(services)) {
     const { commands, eventHandlers } = service;

--- a/src/services/types.d.ts
+++ b/src/services/types.d.ts
@@ -1,8 +1,13 @@
 import { Infra } from '../infra/types';
 
-type Payload<Meta = unknown, Data = unknown> = { meta: Meta, data: Data };
+export interface DefaultMeta {
+  operationId: string;
+  [key: string]: unknown;
+}
 
-export type Command<Meta = unknown, Data = unknown, Returns = unknown> = (
+type Payload<Meta = DefaultMeta, Data = unknown> = { meta: Meta, data: Data };
+
+export type Command<Meta = DefaultMeta, Data = unknown, Returns = unknown> = (
   infra: Infra,
   payload: Payload<Meta, Data>,
 ) => Promise<Returns>;
@@ -32,13 +37,23 @@ interface ServiceError {
   message: string;
 }
 
-export type WrappedCommandResult = [ServiceError | null, any];
+export function processServiceError(
+  error: any,
+  logger: Infra['logger'], 
+  options: { operationId: string, logPrefix: string },
+): ServiceError;
+
+export type WrappedResult = [ServiceError | null, any];
+
+export interface WrapOptions {
+  logPrefix: string;
+}
+
 export function wrapCommand(
   infra: Infra,
   command: Command,
-): (payload: Payload) => Promise<WrappedCommandResult>;
-type AsyncFunc = (...args: any[]) => Promise<any>;
-export function handleServiceError(func: AsyncFunc): (...args: any[]) => Promise<WrappedCommandResult>;
+  options: WrapOptions,
+): (payload: Payload) => Promise<WrappedResult>;
 
 export function init(infra: Infra): Promise<void>;
 

--- a/src/services/types.d.ts
+++ b/src/services/types.d.ts
@@ -1,6 +1,6 @@
 import { Infra } from '../infra/types';
 
-type Payload<Meta, Data> = { meta: Meta, data: Data };
+type Payload<Meta = unknown, Data = unknown> = { meta: Meta, data: Data };
 
 export type Command<Meta = unknown, Data = unknown, Returns = unknown> = (
   infra: Infra,
@@ -26,6 +26,19 @@ export function initEventHandlers(
   infra: Infra,
   eventHandlers: Record<string, EventHandler>,
 ): void;
+
+interface ServiceError {
+  expected: boolean;
+  message: string;
+}
+
+export type WrappedCommandResult = [ServiceError | null, any];
+export function wrapCommand(
+  infra: Infra,
+  command: Command,
+): (payload: Payload) => Promise<WrappedCommandResult>;
+type AsyncFunc = (...args: any[]) => Promise<any>;
+export function handleServiceError(func: AsyncFunc): (...args: any[]) => Promise<WrappedCommandResult>;
 
 export function init(infra: Infra): Promise<void>;
 

--- a/src/services/types.d.ts
+++ b/src/services/types.d.ts
@@ -34,6 +34,7 @@ export function initCommands(
 
 export function initEventHandlers(
   infra: Infra,
+  serviceName: string,
   eventHandlers: Record<string, EventHandler>,
 ): void;
 
@@ -52,5 +53,11 @@ export function wrapCommand(
   command: Command,
   options: WrapOptions,
 ): (payload: Payload<DefaultMeta>) => Promise<CommandResult>;
+
+export function wrapEventHandler(
+  infra: Infra,
+  command: EventHandler,
+  options: WrapOptions,
+): (payload: Payload<DefaultMeta>) => Promise<void>;
 
 export function wrapInfra(infra: Infra, operationId: string): WrappedInfra;


### PR DESCRIPTION
- added wrapper to service commands and event handlers
- added error handling inside wrapper
- added `operationId` propagation to be able to trace child calls to bus `publish` and `command`

Current implementation allows to easily extend wrapper to support `command`/`eventHandler` level hooks