### PR TITLE
General improvements

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,7 @@
   "rules": {
     "strict": "off",
     "no-use-before-define": "off",
+    "no-console": "error",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/no-unused-vars": ["error", { "ignoreRestSiblings": true }]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,79 @@
-# node-soa
-Node js SOA example
+# Node.js template for (Service-oriented architecture)[https://en.wikipedia.org/wiki/Service-oriented_architecture]
+
+## Components
+
+Template consist of:
+1. Infrastructural services (`src/infra/`)
+1. Application and domain services (`src/services/`)
+1. API layer (`src/api`)
+1. Server with its plugins as a separate unit
+
+Built using:
+ - `fastify` and its ecosystem - https://www.fastify.io/
+ - `prisma` - https://www.prisma.io/
+ - `redis` - https://redis.io/
+
+Above dependencies can be replaced, but it will probably require some effort since they contain
+a lot of out-of-the-box functionality, that aren't always present in their alternatives.
+
+### Infrastructure
+
+Contains services required by domain and application services to do their job.
+Database connections, logging, messsaging, external API clients - all are valid examples
+of Infrastructural services. Those services contain no logic and as result can be reused
+on any project.
+
+#### Bus
+
+Important part of infrastructure as it helps to decouple different parts of application
+(as a midiator) and also handles communication between services. Implements `Pub/Sub` and
+`Command` interfaces allowing RPC-like calls and handling of events. Additonally contains
+methods for handling schemas and injecting metadata.
+Has 2 implementations - `local` (using `EventEmitter`) and `distributed` (using `redis`)
+for ability to start from monolith and later smoothly transition to microservices.
+
+### Services
+
+This layer contains all app specific logic. Each service consist of `commands` and `eventHandlers`
+implemented using domain function like style where each function receives `infra` as a first
+argument and actual payload as a second. Infrastructe gets injected into each function using
+partial application.
+Services should know only about Infrastructure (interfaces) and `lib` (utility functions, commun
+schemas etc...).
+`src/services/error.js` contains general `ServiceError` that should be used inside services.
+Those errors are caught and processed as expected errors. All other errors are treated as
+internal errors so they cannot be used to communicate to end user.
+`src/services/types.d.ts` contains `Command` and `EventHandler` generic types as well as typings
+for services supporting functions.
+`src/services/services.js` contains logic to initialize services - inject `infra`, wrap into helper
+function and register them to `bus`.
+
+#### Commands
+
+Consist of named commands, each of which consist of `auth`, `input`, `output` schemas and `handler`.
+`auth` schema can contain any metadata to define access to current service function (e.g. list
+of allowed roles or required permissions) - this data will be passed to `auth` service's `verify`
+function along with users data to check access rights.
+`input` and `output` are used to validate `payload` and results, described using JSONSchema
+allowing getting types from it and easy integration into `fastify`'s ecosystem.
+`handler` - service function.
+
+#### EventHandlers
+
+Consist of `eventName` `eventHandler` pairs. Each `eventHandler` is a service function.
+
+### API
+
+This layer maps service commands to external users. Currently supports HTTP requests only.
+Each endpoint definition implements `HTTPRoute` or `HTTPRouteRaw`.
+First one is simple mapping of HTTP's `url`, `method` and `inputSource` to a `command`.
+Second one is used when more flexibility required - it has access to `req`/`res` objects
+inside its `handler` with `bus` injected.
+
+### Server
+
+Contains `fastify` HTTP and WebSocket (currently only for notification like messages) servers.
+Additionally has multiple plugins from `fastify`'s ecosystem (cors, swagger, auth...) as well as
+custom plugins for transforming HTTP mapping into `fastify` route, handling custom auth and
+WebSockets. Currently, `custom-websocket` only emits WS open/close events with `server` and
+`websocket` meta and subscribes to new WS message events for current instance of the server.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Node.js template for (Service-oriented architecture)[https://en.wikipedia.org/wiki/Service-oriented_architecture]
+# Node.js template for [Service-oriented architecture](https://en.wikipedia.org/wiki/Service-oriented_architecture)
 
 ## Components
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint . && tsc --project .",
     "start": "node src/main.js",
     "build": "prisma generate && node ./prisma/sanitise.js",
-    "test": "tap --no-coverage"
+    "test": "NODE_ENV=test tap --no-coverage"
   },
   "repository": {
     "type": "git",

--- a/src/app.js
+++ b/src/app.js
@@ -12,9 +12,14 @@ export const start = async (conf = config) => {
 
   await initServices(infra, config.services);
 
+  const server = await initServer(infra, api, conf.server);
+
   await infra.bus.listen();
 
-  const server = await initServer(infra, api, conf.server);
+  if (config.env !== 'test') {
+    const { host, port } = config.server;
+    await server.listen({ host, port });
+  }
 
   return {
     app: server,

--- a/src/app.js
+++ b/src/app.js
@@ -10,19 +10,21 @@ import {
 export const start = async (conf = config) => {
   const infra = await initInfra(conf.infra);
 
-  await initServices(infra, config.services);
+  await initServices(infra, conf.services);
 
+  await infra.bus.prefetchSchemas();
   const server = await initServer(infra, api, conf.server);
 
   await infra.bus.listen();
 
-  if (config.env !== 'test') {
-    const { host, port } = config.server;
+  if (conf.env !== 'test') {
+    const { host, port } = conf.server;
     await server.listen({ host, port });
   }
 
   return {
     app: server,
+    infra,
     teardown: async () => {
       infra.logger.info('Starting graceful shutdown');
       await teardownServer(infra, server);

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,28 @@
+import config from './config/config.js';
+import * as api from './api/api.js';
+import { init as initInfra, teardown as teardownInfra } from './infra/infra.js';
+import { init as initServices } from './services/services.js';
+import {
+  init as initServer,
+  teardown as teardownServer,
+} from './server/server.js';
+
+export const start = async (conf = config) => {
+  const infra = await initInfra(conf.infra);
+
+  await initServices(infra, config.services);
+
+  await infra.bus.listen();
+
+  const server = await initServer(infra, api, conf.server);
+
+  return {
+    app: server,
+    teardown: async () => {
+      infra.logger.info('Starting graceful shutdown');
+      await teardownServer(infra, server);
+      await teardownInfra(infra);
+      infra.logger.info('App terminated successfully');
+    },
+  };
+};

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -2,9 +2,11 @@
 import infra from './infra.js';
 import services from './services.js';
 import server from './server.js';
+import { nodeEnv } from './util.js';
 
 /** @type Config */
 export default {
+  env: nodeEnv,
   infra,
   services,
   server,

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -1,9 +1,11 @@
 /** @typedef {import('./types').Config} Config */
 import infra from './infra.js';
+import services from './services.js';
 import server from './server.js';
 
 /** @type Config */
 export default {
   infra,
+  services,
   server,
 };

--- a/src/config/server.js
+++ b/src/config/server.js
@@ -1,10 +1,12 @@
 /** @typedef {import('./types').Config['server']} Server */
+import { getServerId } from './util.js';
 
 const host = process.env.HOST ?? '0.0.0.0';
 const port = parseInt(process.env.PORT ?? '8000');
 
 /** @type Server */
 export default {
+  serverId: getServerId(),
   host,
   port,
   enabledApi: { http: true, ws: true },

--- a/src/config/server.js
+++ b/src/config/server.js
@@ -19,8 +19,8 @@ export default {
   },
   auth: {},
   swagger: {
-    title: 'Supelle API',
-    description: 'API docs for Supelle project',
+    title: '{PROJECT} API',
+    description: 'API docs for {PROJECT} project',
     version: '1.0',
     serverUrl: process.env.SERVER_URL ?? `http://${host}:${port}`,
     routePrefix: '/docs',

--- a/src/config/server.js
+++ b/src/config/server.js
@@ -9,6 +9,7 @@ export default {
   host,
   port,
   env: nodeEnv,
+  enabledApi: { http: true, ws: true },
   healthCheckUrl: '/',
   cors: {
     origin: '*',

--- a/src/config/server.js
+++ b/src/config/server.js
@@ -1,5 +1,4 @@
 /** @typedef {import('./types').Config['server']} Server */
-import { nodeEnv } from './util.js';
 
 const host = process.env.HOST ?? '0.0.0.0';
 const port = parseInt(process.env.PORT ?? '8000');
@@ -8,7 +7,6 @@ const port = parseInt(process.env.PORT ?? '8000');
 export default {
   host,
   port,
-  env: nodeEnv,
   enabledApi: { http: true, ws: true },
   healthCheckUrl: '/',
   cors: {

--- a/src/config/services.js
+++ b/src/config/services.js
@@ -1,0 +1,8 @@
+/** @typedef {import('./types').Config['services']} Services */
+
+const enabledServices = process.env.ENABLED_SERVICES?.split(';');
+
+/** @type Services */
+export default {
+  enabledServices: enabledServices ?? 'all',
+};

--- a/src/config/types.d.ts
+++ b/src/config/types.d.ts
@@ -1,7 +1,9 @@
 import { InfraOptions as InfraConfig } from '../infra/types';
+import { ServicesConfig } from '../services/types';
 import { ServerConfig } from '../server/types';
 
 export interface Config {
   infra: InfraConfig;
+  services: ServicesConfig;
   server: ServerConfig;
 }

--- a/src/config/types.d.ts
+++ b/src/config/types.d.ts
@@ -3,6 +3,7 @@ import { ServicesConfig } from '../services/types';
 import { ServerConfig } from '../server/types';
 
 export interface Config {
+  env: string;
   infra: InfraConfig;
   services: ServicesConfig;
   server: ServerConfig;

--- a/src/config/util.js
+++ b/src/config/util.js
@@ -10,4 +10,11 @@ export const requiredEnv = (name) => {
 /** @type {"development" | "production" | "test"} */
 // @ts-ignore
 export const nodeEnv = process.env.NODE_ENV ?? 'development';
-export const serverId = randomUUID();
+
+/** @type {string} */
+let serverId;
+export const getServerId = () => {
+  if (!serverId) serverId = randomUUID();
+
+  return serverId;
+};

--- a/src/infra/bus/distributed.js
+++ b/src/infra/bus/distributed.js
@@ -29,7 +29,7 @@ export class DistributedBus {
 
   #eventsGroupName = 'events';
   #schemasKey = 'internal:schemas';
- 
+
   #proxyMethods = ['call', 'publish'];
 
   /** @type Init */

--- a/src/infra/bus/distributed.test.js
+++ b/src/infra/bus/distributed.test.js
@@ -70,9 +70,9 @@ describe('distributed bus', () => {
     const { handler, ...schema } = dummyService.commands.echo;
     await caller.setSchema('dummyService', 'echo', schema);
 
-    const echoSchema = await receiver.getSchema('dummyService', 'echo');
+    const echoSchema = receiver.getSchema('dummyService', 'echo');
     assert.deepEqual(echoSchema, schema);
-    const missingSchema = await caller.getSchema('dummyService', 'missing');
+    const missingSchema = caller.getSchema('dummyService', 'missing');
     assert.equal(missingSchema, undefined);
   });
 

--- a/src/infra/bus/distributed.test.js
+++ b/src/infra/bus/distributed.test.js
@@ -69,6 +69,7 @@ describe('distributed bus', () => {
     await receiver.listen();
     const { handler, ...schema } = dummyService.commands.echo;
     await caller.setSchema('dummyService', 'echo', schema);
+    await receiver.prefetchSchemas();
 
     const echoSchema = receiver.getSchema('dummyService', 'echo');
     assert.deepEqual(echoSchema, schema);

--- a/src/infra/bus/local.js
+++ b/src/infra/bus/local.js
@@ -40,6 +40,10 @@ export class LocalBus {
     this.#schemas.set(key, schema);
   };
 
+  /** @type IBus['prefetchSchemas'] */
+  // eslint-disable-next-line @typescript-eslint/no-empty-function, class-methods-use-this
+  async prefetchSchemas() {}
+
   /** @type ICommand['call'] */
   call = async ({ service: serviceName, method }, { meta = {}, data }) => {
     const service = this.#services.get(serviceName);

--- a/src/infra/bus/local.js
+++ b/src/infra/bus/local.js
@@ -29,7 +29,7 @@ export class LocalBus {
   async teardown() {}
 
   /** @type IBus['getSchema'] */
-  getSchema = async (service, method) => {
+  getSchema = (service, method) => {
     const key = `${service}:${method}`;
     return this.#schemas.get(key);
   };

--- a/src/infra/bus/types.d.ts
+++ b/src/infra/bus/types.d.ts
@@ -16,7 +16,7 @@ export type CallHandler = ServiceFunction<
 >;
 export type Payload = {
   meta?: Parameters<CallHandler>[0]['meta'];
-  data: Parameters<CallHandler>[0]['meta'];
+  data: Parameters<CallHandler>[0]['data'];
 };
 export type CallResult = Awaited<ReturnType<CallHandler>>;
 

--- a/src/infra/bus/types.d.ts
+++ b/src/infra/bus/types.d.ts
@@ -39,10 +39,7 @@ export interface PubSub {
 export interface Bus extends Command, PubSub {
   listen(): Promise<void>;
   teardown(): Promise<void>;
-  getSchema(
-    service: string,
-    method: string,
-  ): Promise<ValidationSchema | undefined>;
+  getSchema(service: string, method: string): ValidationSchema | undefined;
   setSchema(
     service: string,
     method: string,

--- a/src/infra/bus/types.d.ts
+++ b/src/infra/bus/types.d.ts
@@ -45,6 +45,7 @@ export interface Bus extends Command, PubSub {
     method: string,
     schema: ValidationSchema,
   ): Promise<void>;
+  prefetchSchemas(): Promise<void>;
   withMeta(meta: object): Bus;
 }
 

--- a/src/lib/crypto.d.ts
+++ b/src/lib/crypto.d.ts
@@ -1,3 +1,3 @@
 export function hash(password: string): Promise<string>;
 export function compare(password: string, hash: string): Promise<boolean>;
-export function random(length?: number): string;
+export function random(): string;

--- a/src/lib/crypto.js
+++ b/src/lib/crypto.js
@@ -21,5 +21,4 @@ export const compare = (password, hash) =>
     });
   });
 
-export const random = (length = 36) =>
-  crypto.randomBytes(length).toString('base64');
+export const random = () => crypto.randomUUID();

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,7 @@ const start = async () => {
   const infra = await initInfra(config.infra);
 
   await initServices(infra);
+
   await infra.bus.listen();
 
   const server = await initServer(infra, api, config.server);

--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,7 @@ try {
     process.exit(0);
   });
 } catch (error) {
+  // eslint-disable-next-line no-console
   console.error(error);
   process.exit(1);
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,31 +1,4 @@
-import config from './config/config.js';
-import * as api from './api/api.js';
-import { init as initInfra, teardown as teardownInfra } from './infra/infra.js';
-import { init as initServices } from './services/services.js';
-import {
-  init as initServer,
-  teardown as teardownServer,
-} from './server/server.js';
-
-const start = async () => {
-  const infra = await initInfra(config.infra);
-
-  await initServices(infra);
-
-  await infra.bus.listen();
-
-  const server = await initServer(infra, api, config.server);
-
-  return {
-    app: server,
-    teardown: async () => {
-      infra.logger.info('Starting graceful shutdown');
-      await teardownServer(infra, server);
-      await teardownInfra(infra);
-      infra.logger.info('App terminated successfully');
-    },
-  };
-};
+import { start } from './app.js';
 
 try {
   let stopping = false;

--- a/src/server/plugins/auth/auth.js
+++ b/src/server/plugins/auth/auth.js
@@ -41,14 +41,15 @@ const auth = async (fastify, options) => {
         if (strategy !== 'Bearer' || !token)
           throw new AuthError(401, 'Invalid header');
 
-        const { valid, access, message, session } = await verifyToken(
-          token,
-          definition,
-        );
-        if (!valid) throw new AuthError(401, message);
-        if (!access) throw new AuthError(403, message);
+        const result = await verifyToken(token, definition);
+        if (!('session' in result)) {
+          const { valid, access, message } = result;
+          if (!valid) throw new AuthError(401, message);
+          if (!access) throw new AuthError(403, message);
+          return;
+        }
 
-        req.session = session;
+        req.session = result.session;
       },
     ]);
 

--- a/src/server/plugins/http/http.js
+++ b/src/server/plugins/http/http.js
@@ -1,5 +1,6 @@
 /** @typedef {import('fastify').RouteOptions} RouteOptions */
 /** @typedef {import('./types').HttpPlugin} Plugin */
+/** @typedef {import('./types')} PluginFuncs */
 import fp from 'fastify-plugin';
 import { generateSchema } from './schema.js';
 
@@ -11,44 +12,91 @@ const options = {
 
 /** @type Plugin */
 const http = async (server, options) => {
-  const { api, prefix, getSchema, executeCommand } = options;
+  const { api, prefix, bus } = options;
 
   for (const [service, routes] of Object.entries(api)) {
     for (const route of routes) {
-      const { method, url, inputSource, command } = route;
+      const fullUrl = `${prefix}/${service}${route.url}`;
 
-      const validationSchema = await getSchema(command.service, command.method);
-      if (!validationSchema) {
-        server.log.warn(`Missing schema for ${service}${url}. Ignoring route`);
-        continue;
-      }
+      const routeOptions =
+        'handler' in route
+          ? getRouteOptionsFromRaw(route, fullUrl, bus)
+          : await getRouteOptions(route, service, fullUrl, server, bus);
 
-      const { auth, input, output } = validationSchema;
-      const schema = generateSchema({
-        service,
-        inputSource,
-        ...validationSchema,
-      });
-
-      /** @type RouteOptions */
-      const routeOptions = {
-        method,
-        url: `${prefix}/${service}${url}`,
-        schema,
-        handler: async (req, res) => {
-          const payload = input ? req[inputSource] : {};
-          const { session } = req;
-          const result = await executeCommand(command, payload, { session });
-          const [code, data] = output ? [200, result] : [204, null];
-          res.code(code).send(data);
-        },
-      };
-
-      if (auth) routeOptions.onRequest = server.customAuth(auth);
+      if (!routeOptions) continue;
 
       server.route(routeOptions);
     }
   }
+};
+
+/** @type PluginFuncs['getRouteOptions'] */
+const getRouteOptions = async (route, service, url, server, bus) => {
+  const { method, inputSource, command } = route;
+
+  const validationSchema = await bus.getSchema(command.service, command.method);
+  if (!validationSchema) {
+    server.log.error(`Missing schema for ${url}. Ignoring route`);
+    return null;
+  }
+
+  const { auth, input, output } = validationSchema;
+  const schema = generateSchema({
+    service,
+    inputSource,
+    ...validationSchema,
+  });
+
+  /** @type RouteOptions */
+  const routeOptions = {
+    method,
+    url,
+    schema,
+    handler: async (req, res) => {
+      const { operationId, ...data } = /** @type any */ (
+        input ? req[inputSource] : {}
+      );
+      const { session } = req;
+      const payload = { meta: { ...session, operationId }, data };
+
+      const [err, result] = await bus.call(command, payload);
+
+      if (err) {
+        const [code, message, logLevel] = err.expected
+          ? [400, err.message, 'warn']
+          : [500, 'Internal server error', 'error'];
+
+        server.log[logLevel]({ url, err }, `${service} error`);
+        return res.code(code).send({ message });
+      }
+
+      const [code, response] = output ? [200, result] : [204, null];
+      return res.code(code).send(response);
+    },
+  };
+
+  if (auth) routeOptions.onRequest = server.customAuth(auth);
+
+  return routeOptions;
+};
+
+/** @type PluginFuncs['getRouteOptionsFromRaw'] */
+const getRouteOptionsFromRaw = (route, url, bus) => {
+  const { method, schema, handler, preValidation } = route;
+
+  /** @type RouteOptions */
+  const routeOptions = {
+    method,
+    url,
+    schema,
+    handler: handler.bind(null, bus),
+  };
+
+  if (preValidation) {
+    routeOptions.preValidation = preValidation.bind(null, bus);
+  }
+
+  return routeOptions;
 };
 
 export default fp(http, options);

--- a/src/server/plugins/http/types.d.ts
+++ b/src/server/plugins/http/types.d.ts
@@ -1,19 +1,16 @@
-import type { FastifyPluginAsync, FastifySchema } from 'fastify';
-import type { API, HTTPRoute } from '../../types';
+import type {
+  FastifyInstance,
+  FastifyPluginAsync,
+  FastifySchema,
+  RouteOptions,
+} from 'fastify';
+import type { API, HTTPRoute, HTTPRouteRaw, Bus } from '../../types';
 import type { ValidationSchema } from '../../../services/types';
 
 export interface HttpPluginOptions {
   prefix: string;
   api: Required<API>['http'];
-  getSchema: (
-    service: string,
-    method: string,
-  ) => Promise<ValidationSchema | undefined>;
-  executeCommand: (
-    command: { service: string; method: string },
-    meta: any,
-    payload: any,
-  ) => Promise<any>;
+  bus: Bus;
 }
 
 export interface SchemaOptions
@@ -21,6 +18,19 @@ export interface SchemaOptions
     Pick<HTTPRoute, 'inputSource'> {
   service: string;
 }
+
+export function getRouteOptions(
+  route: HTTPRoute,
+  service: string,
+  fullUrl: string,
+  server: FastifyInstance,
+  bus: Bus,
+): Promise<RouteOptions | null>;
+export function getRouteOptionsFromRaw(
+  route: HTTPRouteRaw,
+  fullUrl: string,
+  bus: Bus,
+): RouteOptions;
 
 export function generateSchema(options: SchemaOptions): FastifySchema;
 

--- a/src/server/plugins/http/types.d.ts
+++ b/src/server/plugins/http/types.d.ts
@@ -21,11 +21,10 @@ export interface SchemaOptions
 
 export function getRouteOptions(
   route: HTTPRoute,
-  service: string,
   fullUrl: string,
-  server: FastifyInstance,
   bus: Bus,
-): Promise<RouteOptions | null>;
+  server: FastifyInstance,
+): RouteOptions | null;
 export function getRouteOptionsFromRaw(
   route: HTTPRouteRaw,
   fullUrl: string,

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -33,7 +33,8 @@ export const init = async (infra, api, options) => {
     },
   });
 
-  if (api.http) {
+  const { enabledApi } = options;
+  if (enabledApi.http && api.http) {
     await server.register(customHttp, {
       api: api.http,
       prefix: '/api',
@@ -41,7 +42,7 @@ export const init = async (infra, api, options) => {
     });
   }
 
-  if (api.ws) {
+  if (enabledApi.ws && api.ws) {
     await server.register(customWebsocket, {
       serverId,
       bus,

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -37,9 +37,7 @@ export const init = async (infra, api, options) => {
     await server.register(customHttp, {
       api: api.http,
       prefix: '/api',
-      getSchema: bus.getSchema,
-      executeCommand: (command, payload, meta) =>
-        bus.call(command, { meta, data: payload }),
+      bus,
     });
   }
 

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -49,17 +49,13 @@ export const init = async (infra, api, options) => {
     });
   }
 
-  const { host, port, env, healthCheckUrl } = options;
-
-  server.get(healthCheckUrl, async (_req, res) => {
+  server.get(options.healthCheckUrl, async (_req, res) => {
     const dbHealthy = await db.$queryRaw`SELECT 1`.catch(() => false);
 
     const allGood = dbHealthy;
 
     return res.code(allGood ? 200 : 503).send('OK');
   });
-
-  if (env !== 'test') await server.listen({ host, port });
 
   return server;
 };

--- a/src/server/types.d.ts
+++ b/src/server/types.d.ts
@@ -4,13 +4,24 @@ import type { FastifyAuthPluginOptions } from '@fastify/auth';
 import type { SwaggerPluginOptions } from './plugins/swagger/types';
 import type { Infra } from '../infra/types';
 
+export type Bus = Infra['bus'];
+
 export interface HTTPRoute extends Pick<RouteOptions, 'method' | 'url'> {
   inputSource: 'body' | 'query';
   command: { service: string; method: string };
 }
 
+export interface HTTPRouteRaw
+  extends Pick<RouteOptions, 'method' | 'url' | 'schema'> {
+  preValidation?: (bus: Bus) => RouteOptions['preValidation'];
+  handler: (bus: Bus) => RouteOptions['handler'];
+}
+
 export type Server = FastifyInstance;
-export type API = { http?: Record<string, HTTPRoute[]>; ws?: any };
+export type API = {
+  http?: Record<string, (HTTPRoute | HTTPRouteRaw)[]>;
+  ws?: any;
+};
 
 export interface ServerConfig {
   host: string;

--- a/src/server/types.d.ts
+++ b/src/server/types.d.ts
@@ -24,6 +24,7 @@ export type API = {
 };
 
 export interface ServerConfig {
+  serverId: string;
   host: string;
   port: number;
   enabledApi: {

--- a/src/server/types.d.ts
+++ b/src/server/types.d.ts
@@ -31,7 +31,6 @@ export interface ServerConfig {
     ws: boolean;
   };
   healthCheckUrl: string;
-  env: string;
   cors: FastifyCorsOptions;
   auth: FastifyAuthPluginOptions;
   swagger: SwaggerPluginOptions;

--- a/src/server/types.d.ts
+++ b/src/server/types.d.ts
@@ -26,6 +26,10 @@ export type API = {
 export interface ServerConfig {
   host: string;
   port: number;
+  enabledApi: {
+    http: boolean;
+    ws: boolean;
+  };
   healthCheckUrl: string;
   env: string;
   cors: FastifyCorsOptions;

--- a/src/services/account/account.js
+++ b/src/services/account/account.js
@@ -13,6 +13,7 @@ import {
 
 /** @type Commands['deposit'] */
 const deposit = {
+  auth: {},
   input: depositInput,
   handler: async (infra, { data: { accountId, amount } }) => {
     const { db, bus } = infra;
@@ -29,12 +30,13 @@ const deposit = {
         typeExternal: 'deposit',
       },
     });
-    bus.publish('account.deposit', { data: { accountId, amount } });
+    await bus.publish('account:deposit', { data: { accountId, amount } });
   },
 };
 
 /** @type Commands['withdraw'] */
 const withdraw = {
+  auth: {},
   input: withdrawInput,
   handler: async (infra, { data: { accountId, amount } }) => {
     const { db, bus } = infra;
@@ -56,12 +58,13 @@ const withdraw = {
         },
       });
     });
-    bus.publish('account.withdraw', { data: { accountId, amount } });
+    await bus.publish('account:withdraw', { data: { accountId, amount } });
   },
 };
 
 /** @type Commands['transfer'] */
 const transfer = {
+  auth: {},
   input: transferInput,
   handler: async (infra, { data: { fromId, toId, amount } }) => {
     const { db, bus } = infra;
@@ -90,8 +93,7 @@ const transfer = {
         },
       });
     });
-    bus.publish('account.transfer', {
-      meta: {},
+    await bus.publish('account:transfer', {
       data: {
         fromId,
         toId,
@@ -107,8 +109,7 @@ const transfer = {
         amount,
       },
     });
-    bus.publish('account.transfer', {
-      meta: {},
+    await bus.publish('account:transfer', {
       data: {
         fromId,
         toId,
@@ -126,8 +127,7 @@ const transfer = {
         typeExternal: 'deposit',
       },
     });
-    bus.publish('account.transfer', {
-      meta: {},
+    await bus.publish('account:transfer', {
       data: {
         fromId,
         toId,
@@ -140,6 +140,7 @@ const transfer = {
 
 /** @type Commands['getBalance'] */
 const getBalance = {
+  auth: {},
   input: getBalanceInput,
   output: getBalanceOutput,
   handler: async (infra, { data: { accountId } }) => {
@@ -150,6 +151,7 @@ const getBalance = {
 
 /** @type Commands['getTransactions'] */
 const getTransactions = {
+  auth: {},
   input: getTransactionsInput,
   output: getTransactionsOutput,
   handler: async (infra, { data: { accountId } }) => {

--- a/src/services/auth/auth.js
+++ b/src/services/auth/auth.js
@@ -32,7 +32,7 @@ const signUp = {
     const token = crypto.random();
     await db.session.create({ data: { userId, token } });
 
-    bus.publish('auth.signUp', { meta: {}, data: { email } });
+    await bus.publish('auth:signUp', { meta: {}, data: { email } });
 
     return { userId, token };
   },

--- a/src/services/error.js
+++ b/src/services/error.js
@@ -3,13 +3,9 @@
 export class ServiceError extends Error {}
 
 /** @type ServiceFuncs['processServiceError'] */
-export const processServiceError = (error, logger, options) => {
-  const { logPrefix, meta } = options;
+export const processServiceError = (error, logger) => {
   const expected = error instanceof ServiceError;
   const { message, stack } = error;
-  logger[expected ? 'warn' : 'error'](
-    { stack, meta },
-    `[${logPrefix}] ${message}`,
-  );
+  logger[expected ? 'warn' : 'error']({ stack }, message);
   return { message, expected };
 };

--- a/src/services/notification/notification.js
+++ b/src/services/notification/notification.js
@@ -3,20 +3,20 @@ import { ServiceError } from '../error.js';
 
 const initialisedUsers = new Map();
 
-/** @type EventHandlers['ws.connection.open'] */
+/** @type EventHandlers['ws:connection:open'] */
 const wsConnectionOpen = async (_i, { meta, data }) => {
   const { serverId, wsId } = meta;
   const { userId } = data;
   initialisedUsers.set(userId, { serverId, wsId });
 };
 
-/** @type EventHandlers['ws.connection.close'] */
+/** @type EventHandlers['ws:connection:close'] */
 const wsConnectionClose = async (_i, { data }) => {
   const { userId } = data;
   initialisedUsers.delete(userId);
 };
 
-/** @type EventHandlers['account.transfer'] */
+/** @type EventHandlers['account:transfer'] */
 const accountTransfer = async (infra, { data }) => {
   const { db, bus } = infra;
   const { fromId, toId, amount, state } = data;
@@ -37,7 +37,7 @@ const accountTransfer = async (infra, { data }) => {
   if (senderMeta) {
     const { serverId, wsId } = senderMeta;
     const fullName = `${receiver.owner.firstName} ${receiver.owner.lastName}`;
-    bus.publish(`ws.message.${serverId}`, {
+    await bus.publish(`ws:message:${serverId}`, {
       meta: { wsId },
       data: { message: `Successfully sent ${amount}$ to ${fullName}` },
     });
@@ -47,7 +47,7 @@ const accountTransfer = async (infra, { data }) => {
   if (receiverMeta) {
     const { serverId, wsId } = receiverMeta;
     const fullName = `${sender.owner.firstName} ${sender.owner.lastName}`;
-    bus.publish(`ws.message.${serverId}`, {
+    await bus.publish(`ws:message:${serverId}`, {
       meta: { wsId },
       data: {
         message: `Successfully received ${amount}$ from ${fullName}`,
@@ -58,7 +58,7 @@ const accountTransfer = async (infra, { data }) => {
 
 /** @type EventHandlers */
 export const eventHandlers = {
-  'ws.connection.open': wsConnectionOpen,
-  'ws.connection.close': wsConnectionClose,
-  'account.transfer': accountTransfer,
+  'ws:connection:open': wsConnectionOpen,
+  'ws:connection:close': wsConnectionClose,
+  'account:transfer': accountTransfer,
 };

--- a/src/services/notification/types.d.ts
+++ b/src/services/notification/types.d.ts
@@ -24,7 +24,7 @@ export type AccountTransfer = EventHandler<{
 }>;
 
 export interface NotificationEventHandlers {
-  'ws.connection.open': WSConnectionOpen;
-  'ws.connection.close': WSConnectionClose;
-  'account.transfer': AccountTransfer;
+  'ws:connection:open': WSConnectionOpen;
+  'ws:connection:close': WSConnectionClose;
+  'account:transfer': AccountTransfer;
 }

--- a/src/services/services.js
+++ b/src/services/services.js
@@ -13,8 +13,10 @@ const services = {
 };
 
 /** @type ServiceFuncs['init'] */
-export const init = async (infra) => {
+export const init = async (infra, config) => {
+  const { enabledServices: enabled } = config;
   for (const [serviceName, service] of Object.entries(services)) {
+    if (enabled !== 'all' && !enabled.includes(serviceName)) continue;
     const { commands, eventHandlers } = service;
     if (commands) await initCommands(infra, serviceName, commands);
     if (eventHandlers) initEventHandlers(infra, serviceName, eventHandlers);

--- a/src/services/services.js
+++ b/src/services/services.js
@@ -31,7 +31,7 @@ const initCommands = async (infra, serviceName, commands) => {
   for (const [commandName, command] of Object.entries(commands)) {
     const { handler, ...schema } = command;
     const wrapped = wrapServiceFunction(infra, handler, {
-      logPrefix: `${serviceName}/${commandName}`,
+      source: `${serviceName}/${commandName}`,
     });
     initialized[commandName] = wrapped;
     await infra.bus.setSchema(serviceName, commandName, schema);
@@ -44,7 +44,7 @@ const initCommands = async (infra, serviceName, commands) => {
 const initEventHandlers = (infra, serviceName, handlers) => {
   for (const [eventName, handler] of Object.entries(handlers)) {
     const wrapped = wrapServiceFunction(infra, handler, {
-      logPrefix: `${serviceName} - ${eventName}`,
+      source: `${serviceName} - ${eventName}`,
     });
     infra.bus.subscribe(eventName, wrapped);
   }
@@ -52,18 +52,20 @@ const initEventHandlers = (infra, serviceName, handlers) => {
 
 /** @type ServiceFuncs['wrapServiceFunction'] */
 const wrapServiceFunction = (infra, fn, options) => async (payload) => {
-  const { logger, bus } = infra;
-  const { logPrefix } = options;
+  const { bus } = infra;
+  const { source } = options;
   const { meta } = payload;
+  const logger = infra.logger.child({ meta, source });
   try {
-    const wrappedInfra = { ...infra, bus: bus.withMeta(meta) };
+    const wrappedInfra = {
+      ...infra,
+      bus: bus.withMeta(meta),
+      logger,
+    };
     const result = await fn(wrappedInfra, payload);
     return [null, result];
   } catch (error) {
-    const serviceError = processServiceError(error, logger, {
-      meta,
-      logPrefix,
-    });
+    const serviceError = processServiceError(error, logger);
     return [serviceError, null];
   }
 };

--- a/src/services/types.d.ts
+++ b/src/services/types.d.ts
@@ -4,8 +4,9 @@ export interface ServicesConfig {
   enabledServices: 'all' | string[];
 }
 
-export interface WrappedInfra extends Omit<Infra, 'bus'> {
+export interface WrappedInfra extends Omit<Infra, 'bus' | 'logger'> {
   bus: Pick<Infra['bus'], 'call' | 'publish'>;
+  logger: Omit<Infra['logger'], 'child'>;
 }
 
 export interface DefaultMeta {
@@ -61,7 +62,7 @@ export type WrappedServiceFunction<
 export function wrapServiceFunction<Fn extends ServiceFunction>(
   infra: Infra,
   fn: Fn,
-  options: { logPrefix: string },
+  options: { source: string },
 ): WrappedServiceFunction<Fn>;
 
 export interface ServiceError {
@@ -71,8 +72,7 @@ export interface ServiceError {
 
 export function processServiceError(
   error: any,
-  logger: Infra['logger'],
-  options: { meta: DefaultMeta; logPrefix: string },
+  logger: WrappedInfra['logger'],
 ): ServiceError;
 
 export function initCommands(

--- a/src/services/types.d.ts
+++ b/src/services/types.d.ts
@@ -1,5 +1,9 @@
 import type { Infra } from '../infra/types';
 
+export interface ServicesConfig {
+  enabledServices: 'all' | string[];
+}
+
 export interface WrappedInfra extends Omit<Infra, 'bus'> {
   bus: Pick<Infra['bus'], 'call' | 'publish'>;
 }
@@ -83,4 +87,4 @@ export function initEventHandlers(
   eventHandlers: Record<string, EventHandler>,
 ): void;
 
-export function init(infra: Infra): Promise<void>;
+export function init(infra: Infra, config: ServicesConfig): Promise<void>;

--- a/test/account/transfer.test.js
+++ b/test/account/transfer.test.js
@@ -1,0 +1,161 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { setTimeout } from 'node:timers/promises';
+import WebSocket from 'ws';
+import { start } from '../../src/app.js';
+import defaultConfig from '../../src/config/config.js';
+import * as crypto from '../../src/lib/crypto.js';
+
+describe('account/transfer', () => {
+  /** @type {Awaited<ReturnType<start>>} */
+  let gateway;
+  /** @type {Awaited<ReturnType<start>>} */
+  let services;
+
+  const userCommon = {
+    firstName: 'Max',
+    lastName: 'Prudnik',
+    passwordHash: 'test',
+  };
+  const sender = { id: 'user1', email: '1@test.com', ...userCommon };
+  const receiver = { id: 'user2', email: '2@test.com', ...userCommon };
+  const sendSession = { userId: sender.id, token: crypto.random() };
+  const recvSession = { userId: receiver.id, token: crypto.random() };
+  const sendAccount = { id: 'account1', userId: sender.id };
+  const recvAccount = { id: 'account2', userId: receiver.id };
+  const initialBalance = 1000;
+
+  before(async () => {
+    const servicesId = crypto.random();
+    const gatewayId = crypto.random();
+
+    services = await start({
+      ...defaultConfig,
+      server: {
+        ...defaultConfig.server,
+        serverId: servicesId,
+        enabledApi: { http: false, ws: false },
+      },
+      services: { enabledServices: 'all' },
+      infra: {
+        ...defaultConfig.infra,
+        // logger: { env: 'development' },
+        bus: {
+          type: 'distributed',
+          serverId: servicesId,
+          readInterval: 100,
+          callTimeout: 2000,
+          maxCallStreamSize: 100,
+          maxEventStreamSize: 100,
+        },
+      },
+    });
+    gateway = await start({
+      ...defaultConfig,
+      server: {
+        ...defaultConfig.server,
+        serverId: gatewayId,
+        enabledApi: { http: true, ws: true },
+      },
+      services: { enabledServices: [] },
+      infra: {
+        ...defaultConfig.infra,
+        // logger: { env: 'development' },
+        bus: {
+          type: 'distributed',
+          serverId: gatewayId,
+          readInterval: 100,
+          callTimeout: 2000,
+          maxCallStreamSize: 100,
+          maxEventStreamSize: 100,
+        },
+      },
+    });
+
+    gateway.infra.logger.info({ gatewayId, servicesId }, 'Servers');
+
+    const { db } = services.infra;
+
+    await db.user.createMany({ data: [sender, receiver] });
+    await db.session.createMany({ data: [sendSession, recvSession] });
+    await db.account.createMany({ data: [sendAccount, recvAccount] });
+    await db.accountStatement.createMany({
+      data: [
+        {
+          accountId: sendAccount.id,
+          balance: initialBalance,
+          date: new Date(),
+        },
+        {
+          accountId: recvAccount.id,
+          balance: initialBalance,
+          date: new Date(),
+        },
+      ],
+    });
+    await db.ledger.createMany({
+      data: [
+        { name: 'HouseCash', type: 'liability' },
+        { name: 'HouseReserve', type: 'liability' },
+      ],
+    });
+  });
+
+  after(async () => {
+    const { db } = services.infra;
+    await db.accountTransaction.deleteMany({});
+    await db.ledgerTransaction.deleteMany({});
+    await db.accountStatement.deleteMany({});
+    await db.account.deleteMany({});
+    await db.ledger.deleteMany({});
+    await db.session.deleteMany({});
+    await db.user.deleteMany({});
+
+    await gateway.teardown();
+    await services.teardown();
+  });
+
+  it('handles transfer', async () => {
+    const { host, port } = defaultConfig.server;
+    await gateway.app.listen({ host, port });
+    const wsUrl = `ws://${host}:${port}/ws`;
+    const sendSocket = new WebSocket(wsUrl, [], {
+      headers: { Authorization: `Bearer ${sendSession.token}` },
+    });
+    const recvSocket = new WebSocket(wsUrl, [], {
+      headers: { Authorization: `Bearer ${recvSession.token}` },
+    });
+    const sendMessages = [];
+    sendSocket.on('message', (msg) =>
+      sendMessages.push(JSON.parse(msg.toString())),
+    );
+    const recvMessages = [];
+    recvSocket.on('message', (msg) =>
+      recvMessages.push(JSON.parse(msg.toString())),
+    );
+
+    await setTimeout(100);
+
+    const amount = 100;
+    const { statusCode } = await gateway.app.inject({
+      method: 'POST',
+      url: '/api/account/transfer',
+      headers: { Authorization: `Bearer ${sendSession.token}` },
+      payload: { fromId: sendAccount.id, toId: recvAccount.id, amount },
+    });
+
+    await setTimeout(200);
+
+    gateway.app.log.warn({ sendMessages, recvMessages });
+    assert.equal(statusCode, 204);
+    const fullName = `${userCommon.firstName} ${userCommon.lastName}`;
+    assert.equal(sendMessages.length, 1);
+    assert.deepEqual(sendMessages[0], {
+      message: `Successfully sent ${amount}$ to ${fullName}`,
+    });
+    assert.equal(recvMessages.length, 1);
+    assert.deepEqual(recvMessages[0], {
+      message: `Successfully received ${amount}$ from ${fullName}`,
+    });
+  });
+});

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -1,10 +1,47 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { start } from '../src/app.js';
+import defaultConfig from '../src/config/config.js';
 
 describe('app', () => {
-  it('starts with default config', async () => {
+  it('starts with current config', async () => {
     const { app, teardown } = await start();
+    const { statusCode } = await app.inject({ method: 'GET', url: '/' });
+    assert.equal(statusCode, 200);
+    await teardown();
+  });
+
+  it('starts as monolith', async () => {
+    const { app, teardown } = await start({
+      ...defaultConfig,
+      server: { ...defaultConfig.server, enabledApi: { http: true, ws: true } },
+      services: { enabledServices: 'all' },
+    });
+    const { statusCode } = await app.inject({ method: 'GET', url: '/' });
+    assert.equal(statusCode, 200);
+    await teardown();
+  });
+
+  it('starts as api gateway', async () => {
+    const { app, teardown } = await start({
+      ...defaultConfig,
+      server: { ...defaultConfig.server, enabledApi: { http: true, ws: true } },
+      services: { enabledServices: [] },
+    });
+    const { statusCode } = await app.inject({ method: 'GET', url: '/' });
+    assert.equal(statusCode, 200);
+    await teardown();
+  });
+
+  it('starts as services server', async () => {
+    const { app, teardown } = await start({
+      ...defaultConfig,
+      server: {
+        ...defaultConfig.server,
+        enabledApi: { http: false, ws: false },
+      },
+      services: { enabledServices: 'all' },
+    });
     const { statusCode } = await app.inject({ method: 'GET', url: '/' });
     assert.equal(statusCode, 200);
     await teardown();

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -16,6 +16,7 @@ describe('app', () => {
       ...defaultConfig,
       server: { ...defaultConfig.server, enabledApi: { http: true, ws: true } },
       services: { enabledServices: 'all' },
+      infra: { ...defaultConfig.infra, bus: { type: 'local' } },
     });
     const { statusCode } = await app.inject({ method: 'GET', url: '/' });
     assert.equal(statusCode, 200);
@@ -27,6 +28,17 @@ describe('app', () => {
       ...defaultConfig,
       server: { ...defaultConfig.server, enabledApi: { http: true, ws: true } },
       services: { enabledServices: [] },
+      infra: {
+        ...defaultConfig.infra,
+        bus: {
+          type: 'distributed',
+          serverId: 'test',
+          readInterval: 100,
+          callTimeout: 500,
+          maxCallStreamSize: 100,
+          maxEventStreamSize: 100,
+        },
+      },
     });
     const { statusCode } = await app.inject({ method: 'GET', url: '/' });
     assert.equal(statusCode, 200);

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -1,0 +1,12 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { start } from '../src/app.js';
+
+describe('app', () => {
+  it('starts with default config', async () => {
+    const { app, teardown } = await start();
+    const { statusCode } = await app.inject({ method: 'GET', url: '/' });
+    assert.equal(statusCode, 200);
+    await teardown();
+  });
+});


### PR DESCRIPTION
- added basic docs
- added options to create `HTTPRouteRaw` endpoints with access to `req`/`res` and `bus` for HTTP-specific tasks (e.g. `cookies`)
- updated startup files to make the app testable
- updated config to allow starting same app as a `gateway` or with some `services`
- added app tests
- added end-to-end test example (`account/transfer`)
- few minor improvements
... and fixed a lot of commutation bugs to make it work 😁